### PR TITLE
Feature/core/promotion

### DIFF
--- a/chess/core/moving.py
+++ b/chess/core/moving.py
@@ -2,7 +2,7 @@ from chess.core.models import Piece, Coordinate
 import copy
 
 
-def move(game, src, dest):
+def move(game, src, dest, promotion_callback=None):
     board = game.board
     piece = board[src.row][src.column]
 
@@ -10,6 +10,25 @@ def move(game, src, dest):
 
     board[src.row][src.column] = Piece.NONE
     board[dest.row][dest.column] = piece
+
+    promotion(game, dest, promotion_callback)
+
+
+def promotion(game, dest, promotion_callback):
+    board = game.board
+    piece = board[dest.row][dest.column]
+
+    promoted_piece = None
+    if piece == Piece.WHITE_PAWN and dest.row == 0:
+        if promotion_callback is None:
+            promoted_piece = Piece.WHITE_QUEEN
+        else:
+            promoted_piece = promotion_callback()
+    elif piece == Piece.BLACK_PAWN and dest.row == 7:
+        promoted_piece = Piece.BLACK_QUEEN
+
+    if promoted_piece is not None:
+        board[dest.row][dest.column] = promoted_piece
 
 
 def castling(game, src, dest):

--- a/tests/special_moves/promotion_test.py
+++ b/tests/special_moves/promotion_test.py
@@ -1,0 +1,72 @@
+from chess.core.moving import move
+from chess.core.models import Piece, Coordinate
+from chess.core.utils import empty_board, set_at, piece_at
+from chess.core.game import Game
+
+
+def test_promotion_change_to_specified_piece():
+    game = Game()
+    game.board = empty_board()
+    white_pawn_coordinate_src = Coordinate(1, 4)
+    white_pawn_coordinate_dest = white_pawn_coordinate_src.up()
+    set_at(game.board, white_pawn_coordinate_src, Piece.WHITE_PAWN)
+
+    def promotion_callback():
+        return Piece.WHITE_KNIGHT
+
+    move(game,
+         white_pawn_coordinate_src,
+         white_pawn_coordinate_dest,
+         promotion_callback)
+
+    assert (piece_at(game.board, white_pawn_coordinate_dest) ==
+            Piece.WHITE_KNIGHT)
+
+
+def test_promotion_change_to_white_queen():
+    game = Game()
+    game.board = empty_board()
+    white_pawn_coordinate_src = Coordinate(1, 4)
+    white_pawn_coordinate_dest = white_pawn_coordinate_src.up()
+    set_at(game.board, white_pawn_coordinate_src, Piece.WHITE_PAWN)
+
+    move(game,
+         white_pawn_coordinate_src,
+         white_pawn_coordinate_dest)
+
+    assert (piece_at(game.board, white_pawn_coordinate_dest) ==
+            Piece.WHITE_QUEEN)
+
+
+def test_promotion_change_to_black_queen():
+    game = Game()
+    game.board = empty_board()
+    black_pawn_coordinate_src = Coordinate(6, 4)
+    black_pawn_coordinate_dest = black_pawn_coordinate_src.down()
+    set_at(game.board, black_pawn_coordinate_src, Piece.BLACK_PAWN)
+
+    move(game,
+         black_pawn_coordinate_src,
+         black_pawn_coordinate_dest)
+
+    assert (piece_at(game.board, black_pawn_coordinate_dest) ==
+            Piece.BLACK_QUEEN)
+
+
+def test_no_promotion():
+    game = Game()
+    game.board = empty_board()
+    white_pawn_coordinate_src = Coordinate(2, 4)
+    white_pawn_coordinate_dest = white_pawn_coordinate_src.up()
+    set_at(game.board, white_pawn_coordinate_src, Piece.WHITE_PAWN)
+
+    def promotion_callback():
+        return Piece.WHITE_KNIGHT
+
+    move(game,
+         white_pawn_coordinate_src,
+         white_pawn_coordinate_dest,
+         promotion_callback)
+
+    assert (piece_at(game.board, white_pawn_coordinate_dest) ==
+            Piece.WHITE_PAWN)


### PR DESCRIPTION
Implementa a funcionalidade de promoção do peão descrita na issue #54 .
O parâmetro `promotion_callback` pode ser utilizado pela camada de UI para escolher a peça para a qual o peão será promovido.